### PR TITLE
商品詳細表示実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,10 @@ class ItemsController < ApplicationController
 
  before_action :authenticate_user!, except: [:index, :show]
 
+ def show
+  @item = Item.find(params[:id])
+ end
+
  def index
   @items = Item.order(created_at: :desc)
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,7 +131,7 @@
         <% @items.each do |item| %> 
   <li class='list'>
 
-  <%= link_to "#" do %>
+  <%= link_to item_path(item) do %>
   <div class='item-img-content'>
 
     <%= image_tag item.image, class: "item-img" %> 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,38 +4,36 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <%= image_tag @item.image, class:"item-image",size: "600x500"%>
+      <%# 商品が売れている場合は、sold outを表示しましょう 商品購入機能実装後に使う%>
+       <%# if  item.orders != nil %>   
+              <%#div class='sold-out'>   
+                <span>Sold Out!!</span> 
+              </div>    
+            <% end %>
+      <%# //商品が売れている場合は、sold outを表示しましょう商品購入機能実装後に使う %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+       <%= @item.item_price %>
       </span>
       <span class="item-postage">
         <%= "配送料負担" %>
       </span>
     </div>
-
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+ 
+   <% if user_signed_in? %>
+  <% if current_user.id == @item.user_id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+  <% else %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+  <% end %>
+<% end %>
 
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -44,27 +42,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%=  @item.item_category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.item_sales_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.item_shipping_fee_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%=  @item.item_prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%=  @item.item_scheduled_delivery.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -21,7 +21,7 @@
        <%= @item.item_price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.item_shipping_fee_status.name %>
       </span>
     </div>
  
@@ -36,7 +36,7 @@
 
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%=  @item.item_info %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -101,9 +101,9 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  
+  <a href="#" class="another-item"><%= @item.item_category.name %>をもっと見る</a>
+  
 </div>
 
 <%= render "shared/footer" %>


### PR DESCRIPTION
#what
商品詳細表示

＃ｗｈｙ
商品詳細表示を実装するため
https://github.com/koyuzu0310/furima-39896/compare/%E5%95%86%E5%93%81%E8%A9%B3%E7%B4%B0%E8%A1%A8%E7%A4%BA?expand=1

 ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/24f49d09ead99c28214e7ba7841794ba

 ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/d2bd7b60238808f854da1413d3272718

ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
現段階で商品購入機能実装ができていないため動画なし

