### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,19 +1,28 @@
 class ItemsController < ApplicationController
 
- before_action :authenticate_user!, except: [:index, :show]
+ before_action :authenticate_user!, except: [:index, :show,]
+ before_action :move_to_index, except: [:index, :show]
 
+ def move_to_index
+  unless user_signed_in?
+    redirect_to action: :index
+  end
+end
+ 
  def edit
   @item = Item.find(params[:id])
 end
 
 
- def update
-  item = Item.find(params[:id])
-  item.update(item_params)
-  redirect_to root_path
+def update
+  @item = Item.find(params[:id])
+  if @item.update(item_params)
+    redirect_to root_path, notice: "アイテムが更新されました"
+  else
+    render :edit, status: :unprocessable_entity
+  end
 end
 
- 
 
  def show
   @item = Item.find(params[:id])
@@ -40,7 +49,7 @@ end
   def item_params
     params.require(:item).permit(:image, :item_name, :item_info, :item_category_id, :item_sales_status_id,
       :item_shipping_fee_status_id, :item_prefecture_id, :item_scheduled_delivery_id, :item_price).merge(user_id: current_user.id)
-  end
-
-
 end
+end
+
+

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,19 @@ class ItemsController < ApplicationController
 
  before_action :authenticate_user!, except: [:index, :show]
 
+ def edit
+  @item = Item.find(params[:id])
+end
+
+
+ def update
+  item = Item.find(params[:id])
+  item.update(item_params)
+  redirect_to root_path
+end
+
+ 
+
  def show
   @item = Item.find(params[:id])
  end
@@ -29,9 +42,5 @@ end
       :item_shipping_fee_status_id, :item_prefecture_id, :item_scheduled_delivery_id, :item_price).merge(user_id: current_user.id)
   end
 
- 
-#今回の機能ではまだ使わないためこの状態にする
- #def edit
-  #@item = Item.find(params[:id])
-#end
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,55 +1,60 @@
 class ItemsController < ApplicationController
-
+  before_action :set_item, only: [:edit, :show]
  before_action :authenticate_user!, except: [:index, :show,]
- before_action :move_to_index, except: [:index, :show]
+ before_action :contributor_confirmation, only: [:edit, :update]
 
- def move_to_index
-  unless user_signed_in?
-    redirect_to action: :index
+ def index
+  @items = Item.order(created_at: :desc)
+end
+
+def new
+  @item = Item.new
+end
+
+def show
+  @item = Item.find(params[:id])
+ end
+
+ def create
+  @item = Item.new(item_params)
+  if @item.save
+    redirect_to item_path
+  else
+    render :new, status: :unprocessable_entity
   end
 end
- 
- def edit
-  @item = Item.find(params[:id])
-end
 
+def edit
+  if current_user != @item.user
+    redirect_to root_path
+  end
+end
 
 def update
   @item = Item.find(params[:id])
   if @item.update(item_params)
-    redirect_to root_path, notice: "アイテムが更新されました"
+    redirect_to item_path
   else
     render :edit, status: :unprocessable_entity
   end
 end
 
 
- def show
-  @item = Item.find(params[:id])
- end
-
- def index
-  @items = Item.order(created_at: :desc)
-end
-  def new
-    @item = Item.new
-  end
-
-  def create
-    @item = Item.new(item_params)
-    if @item.save
-      redirect_to root_path
-    else
-      render :new, status: :unprocessable_entity
-
-    end
-  end
-
-  private
+private
   def item_params
     params.require(:item).permit(:image, :item_name, :item_info, :item_category_id, :item_sales_status_id,
       :item_shipping_fee_status_id, :item_prefecture_id, :item_scheduled_delivery_id, :item_price).merge(user_id: current_user.id)
 end
+
+ def set_item
+  @item = Item.find(params[:id])
+end
+
+def contributor_confirmation
+  redirect_to action: :index unless current_user == @item&.user
+end
+
+
 end
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,9 @@
+#綺麗に直したやつ（edit　update 動く内容のものにへんこうしている。）
 class ItemsController < ApplicationController
+  before_action :authenticate_user!, except: [:index, :show,]
   before_action :set_item, only: [:edit, :show]
- before_action :authenticate_user!, except: [:index, :show,]
  before_action :contributor_confirmation, only: [:edit, :update]
-
+ 
  def index
   @items = Item.order(created_at: :desc)
 end
@@ -11,9 +12,6 @@ def new
   @item = Item.new
 end
 
-def show
-  @item = Item.find(params[:id])
- end
 
  def create
   @item = Item.new(item_params)
@@ -24,13 +22,18 @@ def show
   end
 end
 
+def show
+  @item = Item.find(params[:id])
+end
+
 def edit
   if current_user != @item.user
     redirect_to root_path
   end
 end
 
-def update
+
+ def update
   @item = Item.find(params[:id])
   if @item.update(item_params)
     redirect_to item_path
@@ -40,17 +43,19 @@ def update
 end
 
 
+
 private
   def item_params
     params.require(:item).permit(:image, :item_name, :item_info, :item_category_id, :item_sales_status_id,
       :item_shipping_fee_status_id, :item_prefecture_id, :item_scheduled_delivery_id, :item_price).merge(user_id: current_user.id)
 end
 
- def set_item
+def set_item
   @item = Item.find(params[:id])
 end
 
 def contributor_confirmation
+set_item
   redirect_to action: :index unless current_user == @item&.user
 end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 #綺麗に直したやつ（edit　update 動く内容のものにへんこうしている。）
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show,]
-  before_action :set_item, only: [:edit, :show]
+  before_action :set_item, only: [:edit, :show, :update]
  before_action :contributor_confirmation, only: [:edit, :update]
  
  def index
@@ -23,7 +23,6 @@ end
 end
 
 def show
-  @item = Item.find(params[:id])
 end
 
 def edit
@@ -34,7 +33,6 @@ end
 
 
  def update
-  @item = Item.find(params[:id])
   if @item.update(item_params)
     redirect_to item_path
   else

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -10,8 +10,8 @@ app/assets/stylesheets/items/new.css %>
     <%= form_with model:@item, local: true do |f| %>
 
    
-    <%= render 'shared/error_messages', model: @item %>
-    
+    <%= render 'shared/error_messages', model:f.object %>
+
     <%# 商品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">
@@ -140,7 +140,8 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+         <%=link_to 'もどる', item_path, class:"back-btn" %>
+
     </div>
     <%# /下部ボタン %>
   </div>
@@ -152,7 +153,7 @@ app/assets/stylesheets/items/new.css %>
       <li><a href="#">フリマ利用規約</a></li>
       <li><a href="#">特定商取引に関する表記</a></li>
     </ul>
-    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <%= link_to image_tag("furima-logo-color.png" , size: '185x50'), "/" %>
     <p class="inc">
       ©︎Furima,Inc.
     </p>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,12 +7,11 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model:@item, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-
+   
+    <%= render 'shared/error_messages', model: @item %>
+    
     <%# 商品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">
@@ -23,7 +22,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +32,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :item_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :item_info, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +51,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:item_category_id, ItemCategory.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:item_sales_status_id, ItemSalesStatus.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +72,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+         <%= f.collection_select(:item_shipping_fee_status_id, ItemShippingFeeStatus.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+          <%= f.collection_select(:item_prefecture_id, ItemPrefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+       <%= f.collection_select(:item_scheduled_delivery_id, ItemScheduledDelivery.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +100,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :item_price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,6 @@
 
         <% @items.each do |item| %> 
   <li class='list'>
-
   <%= link_to item_path(item) do %>
   <div class='item-img-content'>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
  
    <% if user_signed_in? %>
   <% if current_user.id == @item.user_id %>
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+<%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
   <% else %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>


### PR DESCRIPTION
#what
商品情報編集機能

＃ｗｈｙ
商品情報編集機能を実装するため
https://github.com/koyuzu0310/furima-39896/compare/%E5%95%86%E5%93%81%E6%83%85%E5%A0%B1%E7%B7%A8%E9%9B%86%E6%A9%9F%E8%83%BD?expand=1

 ・ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/7c196c8e683bcd386acdc81b5c3de9b8

 ・必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/98be2bb035444e115e7719741e3b2eb7

 ・入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/01736e81b7960f85b5ffe26785b56024

・ 何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/1ff7a06cfbbb7def040b63b6214d5b05

 ・ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/6265036a7a4464954c4bc6914c0ead47

 ・ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）
　　　商品購入機能実装していないため動画なし

 ・ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/ab7217f8a7c1a14319c09bea9032296e

 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/4c985acff854815293fbe7c3176d5879
